### PR TITLE
Fix: remove cc comment in default include directories

### DIFF
--- a/src/clang.cr
+++ b/src/clang.cr
@@ -47,7 +47,7 @@ module Clang
       elsif found_include
         line = line.lstrip
         break unless line.starts_with?('.') || line.starts_with?('/')
-        includes << line.chomp
+        includes << line.split(" (", 2)[0].chomp
       end
     end
 


### PR DESCRIPTION
see https://github.com/crystal-lang/crystal_lib/pull/55