### PR TITLE
Fix: invalid pointer dereferencing when trying to extract non-existing comments

### DIFF
--- a/src/cursor.cr
+++ b/src/cursor.cr
@@ -284,11 +284,15 @@ module Clang
     # end
 
     def raw_comment_text
-      Clang.string(LibC.clang_Cursor_getRawCommentText(self))
+      if (ptr = LibC.clang_Cursor_getRawCommentText(self)) && ptr.data
+        Clang.string(ptr)
+      end
     end
 
     def brief_comment_text
-      Clang.string(LibC.clang_Cursor_getBriefCommentText(self))
+      if (ptr = LibC.clang_Cursor_getBriefCommentText(self)) && ptr.data
+        Clang.string(ptr)
+      end
     end
 
     def objc_decl_qualifiers


### PR DESCRIPTION
Here is a code snippet to reproduce the bug this PR is fixing (not sure it's the sexiest way to fix it though):

```
$ crystal eval <<EOF
require "./samples/c2cr/parser"

class TestParser < C2CR::Parser
  def test
    translation_unit.cursor.visit_children do |cursor|
      if @process.everything? || cursor.location.file_name.try(&.ends_with?(@header_name))
        p cursor
        p cursor.raw_comment_text
      end
      Clang::ChildVisitResult::Continue
    end
  end
end

File.tempfile(suffix: ".h") do |file|
  file.print("int some_function(int a);")
  file.close

  TestParser.new(file.path).test
end
EOF

<#Clang::Cursor kind=FunctionDecl spelling="some_function" type=<#Clang::Type kind=FunctionProto spelling="int (int)">>
Invalid memory access (signal 11) at address 0x3e800006b57
[0x55837f29b746] *CallStack::print_backtrace:Int32 +118
[0x55837f28e5d0] __crystal_sigfault_handler +192
[0x7f4f33536d00] ???
[0x7f4f333adc55] ???
[0x55837f29df2a] *String::new<Pointer(UInt8)>:String +10
[0x55837f2df3c9] *Clang::string<struct.LibC::CXString, Bool>:String +89
[0x55837f2df367] *Clang::string<struct.LibC::CXString>:String +55
[0x55837f2df0d0] *Clang::Cursor#raw_comment_text:String +96
[0x55837f28e7ba] ~procProc(Clang::Cursor, LibC::CXChildVisitResult) +202
[0x55837f28eb80] ~procProc(LibC::CXCursor, LibC::CXCursor, Pointer(Void), LibC::CXChildVisitResult) +320
[0x7f4f33466e95] ???
[0x7f4f33468eee] ???
[0x7f4f33468fec] ???
[0x7f4f33466c87] ???
[0x7f4f3346e7ad] clang_visitChildren +269
[0x55837f2df169] *Clang::Cursor#visit_children<&Proc(Clang::Cursor, LibC::CXChildVisitResult)>:UInt32 +137
[0x55837f2dda30] *TestParser#test:UInt32 +144
[0x55837f280d77] __crystal_main +1703
[0x55837f2e3aa6] *Crystal::main_user_code<Int32, Pointer(Pointer(UInt8))>:Nil +6
[0x55837f2e3a09] *Crystal::main<Int32, Pointer(Pointer(UInt8))>:Int32 +41
[0x55837f28b7b6] main +6
[0x7f4f33275ee3] __libc_start_main +243
[0x55837f2805fe] _start +46
[0x0] ???
```

Crystal & LLVM versions:
```
$ crystal --version
Crystal 0.29.0 (2019-06-06)

LLVM: 6.0.1
Default target: x86_64-pc-linux-gnu

```