### PR TITLE
Update Crystal dependency declaration in shards.yml to include Crystal >= 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,8 @@ version: 0.3.0
 authors:
   - Julien Portalier <julien@portalier.com>
 
+crystal: "*"
+
 description: |
   Bindings for libclang
 


### PR DESCRIPTION
Projects that are depending on this library [cannot be built](https://github.com/crystal-lang/shards/issues/413) correctly because of [an implicit dependency](https://github.com/crystal-lang/shards/blob/master/docs/shard.yml.adoc#optional-attributes) on Crystal _<= 0.x_ in the [shards.yml](shards.yml) file.

I've used Crystal _0.24_ as the version as it was the current Crystal version when this project was initially imported (and if I remember correctly that's the first version that I've used in _crystal_lib_).