### PR TITLE
Allow anonymous union in struct

### DIFF
--- a/samples/c2cr/type.cr
+++ b/samples/c2cr/type.cr
@@ -20,10 +20,19 @@ module C2CR
       when .double? then "Double"
       when .long_double? then "LongDouble"
       when .pointer? then visit_pointer(type)
-      when .enum?, .record?
+      when .enum?
         spelling = type.cursor.spelling
         spelling = type.spelling if type.cursor.spelling.empty?
         Constant.to_crystal(spelling)
+      when .record?
+          case type.cursor.kind
+            when .union_decl?
+                visit_record(type)
+            else
+                spelling = type.cursor.spelling
+                spelling = type.spelling if type.cursor.spelling.empty?
+                Constant.to_crystal(spelling)
+            end
       when .elaborated? then to_crystal(type.named_type)
       when .typedef?
         if (spelling = type.spelling).starts_with?('_')
@@ -48,6 +57,10 @@ module C2CR
       #pointee = to_crystal(type.pointee_type.canonical_type)
       pointee = to_crystal(type.pointee_type)
       "#{pointee}*"
+    end
+
+    def self.visit_record(type)
+        "ANONYMOUS_#{type.cursor.semantic_parent.spelling}"
     end
 
     def self.visit_constant_array(type)


### PR DESCRIPTION
ln -s /usr/include/openssl/ openssl

./bin/c2cr -Iopenssl openssl/pkcs7.h

In master there is a error
```
WARNING: unexpected UnionDecl within StructDecl (visit_struct)
```
and the output in the crystal file is invalid.
```crystal
    struct Pkcs7St         
      asn1 : Char*        
      length : Long        
      state : Int            
      detached : Int         
      type : ASN1_OBJECT*    
      d : Union pkcs7St::(anonymous at /usr/include/openssl/pkcs7.h:127:5)    # Error here, needs manual fixing.
    end                     

```

With this Merge request it's usable

```crystal
  union ANONYMOUS_pkcs7_st_1059675872 # Unstable name based on struct & cursor hash value
    ptr : Char*
    data : ASN1_OCTET_STRING*
    sign : PKCS7_SIGNED*
    enveloped : PKCS7_ENVELOPE*
    signed_and_enveloped : PKCS7_SIGN_ENVELOPE*
    digest : PKCS7_DIGEST*
    encrypted : PKCS7_ENCRYPT*
    other : ASN1_TYPE*
  end

  alias ANONYMOUS_pkcs7_st_d = ANONYMOUS_pkcs7_st_1059675872 # Alias it to a more stable name based on struct name & the fieldname separated by "_"

  struct Pkcs7St
    asn1 : Char*
    length : Long
    state : Int
    detached : Int
    type : ASN1_OBJECT*
    d : ANONYMOUS_pkcs7_st_d # Use the stable name
  end
```