### PR TITLE
C2CR: support nested and anonymous structs and unions

### DIFF
--- a/src/cursor.cr
+++ b/src/cursor.cr
@@ -39,6 +39,15 @@ module Clang
       }, Box.box(block))
     end
 
+    def first_child?
+      cursor = nil
+      visit_children do |child|
+        cursor = child
+        Clang::ChildVisitResult::Break
+      end
+      cursor
+    end
+
     def has_attributes?
       LibC.clang_Cursor_hasAttrs(self) == 1
     end


### PR DESCRIPTION
A generic solution to nested and anonymous structs and unions (recursive). Structs and unions may have a name, in which we directly generate them (as if they weren't nested) and when anonymous (`field : struct {};`) we generate the struct/union when we reach the field itself, at which point we know both the struct name _and_ the field name, and can generate a named struct/union definition.

closes #10 